### PR TITLE
Always set DeployedGroupVersionKind

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,7 +6,7 @@ on:
     - 'main'
     - 'dev'
   pull_request:
-    types: opened
+    types: [opened, edited, reopened]
 
 
 jobs:

--- a/controllers/handlers_resources.go
+++ b/controllers/handlers_resources.go
@@ -72,16 +72,17 @@ func deployResources(ctx context.Context, c client.Client,
 	var remoteResourceReports []configv1alpha1.ResourceReport
 	localResourceReports, remoteResourceReports, err = deployReferencedObjects(ctx, c, remoteRestConfig,
 		clusterSummary, featureHandler, logger)
+
+	// Irrespective of error, update deployed gvks. Otherwise cleanup won't happen in case
+	gvkErr := updateDeployedGroupVersionKind(ctx, clusterSummary, localResourceReports, remoteResourceReports, logger)
 	if err != nil {
 		return err
+	}
+	if gvkErr != nil {
+		return gvkErr
 	}
 
 	clusterProfileOwnerRef, err := configv1alpha1.GetClusterProfileOwnerReference(clusterSummary)
-	if err != nil {
-		return err
-	}
-
-	err = updateDeployedGroupVersionKind(ctx, clusterSummary, localResourceReports, remoteResourceReports, logger)
 	if err != nil {
 		return err
 	}

--- a/controllers/handlers_utils.go
+++ b/controllers/handlers_utils.go
@@ -481,18 +481,18 @@ func deployReferencedObjects(ctx context.Context, c client.Client, remoteConfig 
 	}
 	tmpResourceReports, err = deployObjects(ctx, c, localConfig, objectsToDeployLocally, clusterSummary,
 		mgtmResources, logger)
-	if err != nil {
-		return nil, nil, err
-	}
 	localReports = append(localReports, tmpResourceReports...)
+	if err != nil {
+		return localReports, nil, err
+	}
 
 	// Deploy all resources that need to be deployed in the managed cluster
 	tmpResourceReports, err = deployObjects(ctx, remoteClient, remoteConfig, objectsToDeployRemotely, clusterSummary,
 		mgtmResources, logger)
-	if err != nil {
-		return nil, nil, err
-	}
 	remoteReports = append(remoteReports, tmpResourceReports...)
+	if err != nil {
+		return localReports, remoteReports, err
+	}
 
 	return localReports, remoteReports, nil
 }


### PR DESCRIPTION
Cleanup of deployed resources needs to be aware of the GVKs deployed by addon-manager.
If a subset of resources is deployed and then an error happens, before this PR DeployedGroupVersionKind was not set. This causes addon-manager to leave stale resource (on delete, given DeployedGroupVersionKind was not set addon-manager used to clean up nothing).

This PR fixes this behavior by always setting DeployedGroupVersionKind.