### PR TITLE
Add-on constraints: all or nothing

### DIFF
--- a/controllers/openapi_validation.go
+++ b/controllers/openapi_validation.go
@@ -63,7 +63,10 @@ func getOpenAPIValidations(clusterNamespace, clusterName string,
 func runOpenAPIValidations(ctx context.Context, specs map[string][]byte,
 	resource *unstructured.Unstructured, logger logr.Logger) error {
 
-	logger.V(logs.LogDebug).Info("openAPIValidations")
+	logger = logger.WithValues("resource", fmt.Sprintf("%s:%s/%s", resource.GroupVersionKind().Kind,
+		resource.GetNamespace(), resource.GetName()))
+
+	logger.V(logs.LogVerbose).Info("openAPIValidations")
 
 	for key := range specs {
 		if err := openAPIValidation(ctx, specs[key], resource, logger); err != nil {

--- a/controllers/template_instantiation.go
+++ b/controllers/template_instantiation.go
@@ -185,7 +185,7 @@ func instantiateTemplateValues(ctx context.Context, config *rest.Config, c clien
 	}
 	instantiatedValues := buffer.String()
 
-	logger.V(logs.LogVerbose).Info("Values %q", instantiatedValues)
+	logger.V(logs.LogDebug).Info(fmt.Sprintf("Values %q", instantiatedValues))
 	return instantiatedValues, nil
 }
 


### PR DESCRIPTION
Either all resources in an helm chart, configMap/secret or kustomize satisfy current existing constraints, or none will be deployed.